### PR TITLE
all feedbacks refactored

### DIFF
--- a/app/controller/api-controller.js
+++ b/app/controller/api-controller.js
@@ -1,6 +1,6 @@
 const { selectApiEndPoints } = require("../model/select-api");
 
 exports.getApiEndPoints = (req, res, next) => {
-  const result = selectApiEndPoints();
-  res.status(200).send({ endPoints: result });
+  const endPoints = selectApiEndPoints();
+  res.status(200).send({ endPoints });
 };

--- a/app/errors/index.js
+++ b/app/errors/index.js
@@ -7,7 +7,7 @@ exports.handlePsqlErrors = (err, req, res, next) => {
   if (err.code === "22P02" || err.code === "08P01" || err.code === "23502") {
     res.status(400).send({ msg: "Bad Request" });
   } else if (err.code === "23503") {
-    res.status(422).send({ msg: "Not Found" });
+    res.status(404).send({ msg: "Not Found" });
   } else next(err);
 };
 exports.handleServerErrors = (err, req, res, next) => {

--- a/app/model/select-articles.js
+++ b/app/model/select-articles.js
@@ -38,7 +38,7 @@ exports.selectArticles = (topic) => {
   articles.created_at,
   articles.votes,
   articles.article_img_url,
-COUNT(comments.article_id) AS comment_count
+CAST(COUNT(comments.article_id)AS INT) AS comment_count
 FROM articles
 LEFT JOIN comments
 ON articles.article_id = comments.article_id `;


### PR DESCRIPTION

Endpoint: /api/articles/:article_id
GET 400: Responds with the appropriate error when passed the wrong article_id data type
PATCH 400: Should return an error if the article_id datatype is invalid
PATCH 400: Should return an error if object that doesn't have an inc_votes key is sent
used CAST to change all counts to number
used shorthand for keys with the same name

Endpoint: api/articles/:article_id/comments
GET 200: Should return an empty array of comments for an article_id without comments

POST 201: Ignores any unnecessary properties on the request body.
Changed POST 422, to 404
